### PR TITLE
VICI TCP socket support

### DIFF
--- a/strongMan/apps/vici/wrapper/wrapper.py
+++ b/strongMan/apps/vici/wrapper/wrapper.py
@@ -11,7 +11,7 @@ from .exception import ViciSocketException, ViciTerminateException, ViciLoadExce
 class ViciWrapper:
     def __init__(self, socket_uri=None):
         socket_uri = socket_uri or settings.VICI_SOCKET_URI
-        self.socket_uri = parse(socket_uri)
+        self.socket_uri = urlparse(socket_uri)
 
         self._check_socket()
         self._connect_socket()

--- a/strongMan/apps/vici/wrapper/wrapper.py
+++ b/strongMan/apps/vici/wrapper/wrapper.py
@@ -2,21 +2,33 @@ import os, stat
 import socket
 import vici
 from collections import OrderedDict
+from urllib.parse import urlparse
+from django.conf import settings
 from .exception import ViciSocketException, ViciTerminateException, ViciLoadException, ViciInitiateException, \
     ViciPathNotASocketException
 
 
 class ViciWrapper:
-    def __init__(self, socket_path="/var/run/charon.vici"):
-        self.socket_path = socket_path
-        if not os.path.exists(self.socket_path):
-            raise ViciSocketException(self.socket_path + " doesn't exist!")
-        if not self._is_path_a_socket():
-            raise ViciPathNotASocketException("The path '" + self.socket_path + "' is not a Socket!")
+    def __init__(self, socket_uri=None):
+        socket_uri = socket_uri or settings.VICI_SOCKET_URI
+        self.socket_uri = parse(socket_uri)
+
+        self._check_socket()
         self._connect_socket()
 
     def __del__(self):
         self._close_socket()
+
+    def _check_socket(self):
+        if not self.socket_uri.scheme in ["unix", "tcp"]:
+            raise ViciPathNotASocketException(self.socket_uri + "is not a valid socket URI")
+
+        if self.socket_uri.scheme == "unix":
+            if not os.path.exists(self.socket_uri.netloc):
+                raise ViciSocketException(self.socket_uri.netloc + " doesn't exist!")
+
+            if not self._is_path_a_socket():
+                raise ViciPathNotASocketException("The path '" + self.socket_uri.netloc + "' is not a Socket!")
 
     def _close_socket(self):
         try:
@@ -27,14 +39,19 @@ class ViciWrapper:
 
     def _connect_socket(self):
         try:
-            self.socket = socket.socket(socket.AF_UNIX)
-            self.socket.connect(self.socket_path)
+            if self.socket_uri.scheme == "unix":
+                self.socket = socket.socket(socket.AF_UNIX)
+                self.socket.connect(self.socket_uri.netloc)
+            else:
+                self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self.socket.connect((self.socket_uri.hostname, self.socket_uri.port))
+
             self.session = vici.Session(self.socket)
         except Exception as e:
             raise ViciSocketException("Vici is not reachable! " + str(e))
 
     def _is_path_a_socket(self):
-        mode = os.stat(self.socket_path).st_mode
+        mode = os.stat(self.socket_uri.netloc).st_mode
         return stat.S_ISSOCK(mode)
 
     def load_connection(self, connection):

--- a/strongMan/settings/base.py
+++ b/strongMan/settings/base.py
@@ -114,3 +114,10 @@ def create_read_key(file_path):
 
 SECRET_KEY = create_read_key('secret_key.txt')
 DB_SECRET_KEY = create_read_key('db_key.txt')
+
+# VICI socket URI
+# Use either tcp://<hostname>:<port? for TCP sockets,
+# or unix:///path/to/socket for UNIX sockets
+# Default is unix:///var/run/charon.vici
+
+VICI_SOCKET_URI = "unix:///var/run/charon.vici"


### PR DESCRIPTION
This PR adds support for TCP sockets for VICI, allowing to separate the Strongswan server from the server hosting the webapp. That would lower the Strongswan server's attack surface and with some extra work would allow a single StrongMan installation to control multiple servers, by changing the socket URI at runtime (perhaps based on a dropdown selector at login?).

You can set the default socket in the `VICI_SOCKET_URI` configuration variable. It's an URI, if it starts with `unix://` it's a local UNIX socket, if it starts with `tcp://` it's a TCP socket.