### PR TITLE
feat: auto-cleanup old/expired certificates and sync to strongSwan

### DIFF
--- a/configloader.py
+++ b/configloader.py
@@ -55,8 +55,22 @@ def load_credentials(vici=ViciWrapper()):
     load_certificates(vici)
 
 
+def cleanup_expired_certificates():
+    from django.utils import timezone
+    expired = Certificate.objects.filter(valid_not_after__lt=timezone.now())
+    count = expired.count()
+    if count > 0:
+        expired.delete()
+        print(f"Cleaned up {count} expired certificate(s)")
+        return True
+    return False
+
+
 def main():
     vici = ViciWrapper()
+    cleaned = cleanup_expired_certificates()
+    if cleaned:
+        vici.clear_creds()
     load_credentials(vici)
     load_pools(vici)
     load_connections()

--- a/strongMan/apps/certificates/services.py
+++ b/strongMan/apps/certificates/services.py
@@ -56,6 +56,12 @@ class UserCertificateManager(object):
         if cls._certificate_by_hashserial(reader.public_key_hash(), reader.serial_number()) is not None:
             e = CertificateManagerException("Certificate " + reader.cname() + " already exists.")
             return AddKeyContainerResult(False, exceptions=[e])
+        
+        # Remove old certificates with same public key but different serial number
+        old_certs = UserCertificate.objects.filter(public_key_hash=reader.public_key_hash()).exclude(serial_number=reader.serial_number())
+        for old_cert in old_certs:
+            old_cert.delete()
+        
         cert = CertificateFactory.user_certificate_by_x509reader(reader)
         cert.set_privatekey_if_exists()
         cert.save()


### PR DESCRIPTION
- Auto-remove old certificates when uploading new ones with same public key
- Cleanup expired certificates on strongSwan startup and sync via vici

This ensures strongMan database and strongSwan stay in sync when certificates are renewed or expired.

Changes:
- services.py: Remove duplicate certs with same public key on upload
- configloader.py: Cleanup expired certs and sync to strongSwan on startup