### PR TITLE
Update pool handler to improve unloading & deleting pools

### DIFF
--- a/strongMan/apps/pools/views/EditHandler.py
+++ b/strongMan/apps/pools/views/EditHandler.py
@@ -6,6 +6,7 @@ from ..forms import AddOrEditForm
 from strongMan.apps.pools.models import Pool
 from strongMan.helper_apps.vici.wrapper.exception import ViciException
 from strongMan.helper_apps.vici.wrapper.wrapper import ViciWrapper
+from django.db import transaction
 from django.db.models import ProtectedError
 
 
@@ -62,18 +63,20 @@ class EditHandler(object):
             return redirect(reverse("pools:index"))
 
     def delete_pool(self, vici):
-        vici_poolname = {'name': self.poolname}
+        vici_poolname = {"name": self.poolname}
         try:
-            vici.unload_pool(vici_poolname)
-            self.pool.delete()
-            messages.add_message(self.request, messages.SUCCESS, "Pool deletion successful.")
-
+            with transaction.atomic():
+                self.pool.delete()
+                if self.poolname in vici.get_pools(vici_poolname):
+                    vici.unload_pool(vici_poolname)
+                messages.add_message(self.request, messages.SUCCESS, "Pool deletion successful.")
         except ViciException as e:
-            messages.add_message(self.request, messages.ERROR,
-                                 'Unload pool failed: ' + str(e))
-        except ProtectedError:
-            messages.add_message(self.request, messages.ERROR,
-                                 'Pool not deleted. Pool is in use by a connection.')
+            messages.add_message(self.request, messages.ERROR, "Unload pool failed: " + str(e))
+        except ProtectedError as e:
+            names = sorted(obj.profile for obj in e.protected_objects)
+            messages.add_message(
+                self.request, messages.ERROR,
+                f"Pool not deleted! In use by {len(names)} connection(s): {', '.join(names)}")
         except Exception as e:
             messages.add_message(self.request, messages.ERROR, str(e))
         return redirect(reverse("pools:index"))

--- a/strongMan/helper_apps/vici/wrapper/wrapper.py
+++ b/strongMan/helper_apps/vici/wrapper/wrapper.py
@@ -232,9 +232,9 @@ class ViciWrapper(object):
         except Exception:
             return self.session.get_pools()
 
-    def unload_pool(self, pool_name):
+    def unload_pool(self, pool):
         try:
-            self.session.unload_pool(pool_name)
+            self.session.unload_pool(pool)
         except Exception as e:
             raise ViciLoadException(str(e))
 


### PR DESCRIPTION
Updated the Vici wrapper to check if a pool is loaded with `get_pools()` before attempting to unload it. Prevents error when attempting to unload an already-unloaded pool. I also updated the wrapper to just take the name of the pool to unload instead of needing a dict.

Update the pool EditHandler to:

1. Attempt to unload the pool with vici
2. If the pool was unloaded successfully (or wasn't loaded in the first place), only then try to delete it from the DB
3. If the DB delete failed, re-load the pool into Vici
4. If the DB delete failed because of a `ProtectedError` (i.e. in use by a connection), print the number/name of connections using said pool.